### PR TITLE
Update loaf_billing.sql to fix error in syntax

### DIFF
--- a/loaf_billing.sql
+++ b/loaf_billing.sql
@@ -2,7 +2,7 @@
 
 CREATE TABLE IF NOT EXISTS `loaf_invoices` (
     `id` VARCHAR(15), -- unique bill id
-    `issued` DATE DEFAULT CURRENT_DATE, -- the date the bill was issued
+    `issued` DATE DEFAULT (CURRENT_DATE), -- the date the bill was issued
 
     `biller` VARCHAR(150) NOT NULL, -- the identifier who issued the bill
     `biller_name` VARCHAR(150) NOT NULL, -- the name of the person who issued the bill


### PR DESCRIPTION
According the MySQL documentation for it to correctly allow default of CURRENT_DATE it must be put inside of parenthesis.

Used this fix on my SQL import and got no issues comparatively.